### PR TITLE
Try importing from v2, fallback on v1_1

### DIFF
--- a/os_diskconfig_python_novaclient_ext/__init__.py
+++ b/os_diskconfig_python_novaclient_ext/__init__.py
@@ -18,8 +18,13 @@ Disk Config extension
 """
 
 from novaclient import utils
-from novaclient.v1_1 import servers
-from novaclient.v1_1 import shell
+
+try:
+    from novaclient.v2 import servers
+    from novaclient.v2 import shell
+except ImportError:
+    from novaclient.v1_1 import servers
+    from novaclient.v1_1 import shell
 
 API_DISK_CONFIG = "OS-DCF:diskConfig"
 


### PR DESCRIPTION
Release 2.21.0 of python-novaclient deprecates the v1_1 module. This
commit prevents a warning message from being displayed when running
the latest version of python-novaclient.